### PR TITLE
fix wrong lsb-relase codename information and wrong pointing vendor file

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -8,7 +8,7 @@ ifeq ($(DEB_HOST_GNU_SYSTEM),gnu)
   OSNAME=GNU/Hurd
 endif
 
-VENDORFILE = debian
+VENDORFILE = blankon
 DESTDIR = debian/base-files
 
 %:

--- a/etc/lsb-release
+++ b/etc/lsb-release
@@ -1,4 +1,4 @@
 DISTRIB_ID=Blankon
 DISTRIB_RELEASE=12.0
 DISTRIB_CODENAME=verbeek
-DISTRIB_DESCRIPTION="BlankOn Verbeek"
+DISTRIB_DESCRIPTION="BlankOn Verbeek (development branch)"

--- a/etc/os-release
+++ b/etc/os-release
@@ -1,4 +1,4 @@
-PRETTY_NAME="BlankOn #OSNAME# 12 (verbeek)"
+PRETTY_NAME="BlankOn #OSNAME# 12 (development branch)"
 NAME="BlankOn #OSNAME#"
 ID=blankon
 HOME_URL="http://www.blankonlinux.or.id/"

--- a/etc/os-release
+++ b/etc/os-release
@@ -4,3 +4,4 @@ ID=blankon
 HOME_URL="http://www.blankonlinux.or.id/"
 SUPPORT_URL="https://github.com/blankon/verbeek/issues"
 BUG_REPORT_URL="https://github.com/blankon/verbeek/issues"
+VERSION_CODENAME=verbeek


### PR DESCRIPTION
related: https://github.com/BlankOn/Verbeek/issues/177

currently the vendor file (for census purpose, am i right?) is not pointed to the right file. After post install the script will create symlink of `origins/debian` to `/etc/dpkg/origins/default`. The right source file is `origins/blankon` instead of `origins/debian`.

cc @hahn @aftian @antosamalona 